### PR TITLE
EMP-15028 - Add support for passing language to the receiver app 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # CHANGELOG
 
-* `2.2.00` Release - [2.2.00](#2000)
+* `2.2.00` Release - [2.2.10](#2000)
 * `2.0.93` Release - [2.0.93](#2093)
 * `2.0.82` Release - [2.0.82](#2082)
 * `2.0.79` Release - [2.0.79](#2079)
 * `0.73.x` Releases - [0.73.0](#0730)
+
+## 2.2.100
+#### Features
+* `EMP-15028` Now the sender app can pass `language` that should be used for mediainfo in control bar.
+
 
 ## 2.2.000
 

--- a/Cast.xcodeproj/project.pbxproj
+++ b/Cast.xcodeproj/project.pbxproj
@@ -652,7 +652,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = JCUPRVKEC5;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -666,7 +666,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 2.2.00;
+				MARKETING_VERSION = 2.2.1;
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
@@ -686,7 +686,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = JCUPRVKEC5;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -700,7 +700,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 2.2.00;
+				MARKETING_VERSION = 2.2.1;
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",

--- a/Cast/Configuration/CustomData.swift
+++ b/Cast/Configuration/CustomData.swift
@@ -28,6 +28,8 @@ public struct CustomData: Encodable {
     /// Specified text language to use
     public let textLanguage: String?
     
+    public let language: String?
+    
     /// Specified audio language to use
     @available(*, deprecated: 2.0.79, message: "Use PlaybackProperties instead")
     public let startTime: Int64?
@@ -110,6 +112,7 @@ public struct CustomData: Encodable {
                 programId: String? = nil,
                 audioLanguage: String? = nil,
                 textLanguage: String? = nil,
+                language:String? = nil,
                 startTime: Int64? = nil,
                 absoluteStartTime: Int64? = nil,
                 timeShiftDisabled: Bool = false,
@@ -123,6 +126,7 @@ public struct CustomData: Encodable {
         self.programId = programId
         self.audioLanguage = audioLanguage
         self.textLanguage = textLanguage
+        self.language = language
         self.startTime = startTime
         self.absoluteStartTime = absoluteStartTime
         self.timeShiftDisabled = timeShiftDisabled
@@ -141,6 +145,7 @@ extension CustomData {
         case programId
         case audioLanguage
         case textLanguage = "subtitleLanguage"
+        case language
         
         @available(*, deprecated: 2.0.79, message: "Use PlaybackProperties instead")
         case startTime
@@ -199,6 +204,10 @@ extension CustomData {
         
         if let value = maxBitrate {
             json[CodingKeys.maxBitrate.rawValue] = value
+        }
+        
+        if let value = language {
+            json[CodingKeys.language.rawValue] = value
         }
         
         return json

--- a/Cast/Info.plist
+++ b/Cast/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/CastTests/CustomDataSpec.swift
+++ b/CastTests/CustomDataSpec.swift
@@ -24,6 +24,7 @@ class CustomDataSpec: QuickSpec {
                                       programId: "programId",
                                       audioLanguage: "audioLang",
                                       textLanguage: "textLang",
+                                      language: "language",
                                       startTime: 10,
                                       absoluteStartTime: 100,
                                       timeShiftDisabled: true,
@@ -37,6 +38,7 @@ class CustomDataSpec: QuickSpec {
                 expect(data["programId"] as? String).to(equal("programId"))
                 expect(data["audioLanguage"] as? String).to(equal("audioLang"))
                 expect(data["subtitleLanguage"] as? String).to(equal("textLang"))
+                expect(data["language"] as? String).to(equal("language"))
                 expect(data["startTime"] as? Int64).to(equal(10))
                 expect(data["absoluteStartTime"] as? Int64).to(equal(100))
                 expect(data["timeShiftDisabled"] as? Bool).to(equal(true))

--- a/Documentation/chromecast-integration.md
+++ b/Documentation/chromecast-integration.md
@@ -9,6 +9,9 @@
 ### iOS Permissions Changes
 With recent updates to iOS, the operating system will now enforce new restrictions and permissions that affect the Cast user experience. It will also affect how you build the Cast SDK into your app. For your app to maintain Cast functionality with the latest versions of iOS, you must make updates to handle these permissions changes.
 
+`Cast`  library uses the Google Chrome cast sdk which requires Bluetooth® permissions.
+
+
 Please follow the guidelines in this document to support the iOS version your app supports . 
 [`Google Cast `](#https://developers.google.com/cast/docs/ios_sender/ios_permissions_changes)
 


### PR DESCRIPTION
Implement the interface to choose language that should be used for mediainfo in control bar
Update unit tests